### PR TITLE
chore: add eslint with prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+build
+node_modules
+.github

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,78 @@
+module.exports = {
+    env: {
+        browser: true,
+        es6: true,
+        node: true,
+    },
+    extends: [
+        'eslint:recommended',
+        'plugin:react/recommended',
+        'plugin:react-hooks/recommended',
+        'plugin:prettier/recommended',
+        'plugin:jsx-a11y/strict',
+    ],
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true,
+        },
+        ecmaVersion: 2018,
+        sourceType: 'module',
+    },
+    plugins: ['react', 'jsx-a11y', '@typescript-eslint'],
+    rules: {
+        'react/boolean-prop-naming': [
+            'error',
+            {
+                rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+',
+                propTypeNames: ['bool', 'boolean'],
+                message:
+                    'It is better if your prop ({{ propName }}) matches this pattern: ({{ pattern }})',
+                validateNested: true,
+            },
+        ],
+        'react/jsx-curly-brace-presence': ['error'],
+        'react/jsx-boolean-value': ['error', 'always'],
+        'react-hooks/exhaustive-deps': 'error',
+        'react/prop-types': 'off',
+        'no-var': 'error',
+        'brace-style': 'error',
+        'prefer-template': 'error',
+        radix: 'error',
+        'space-before-blocks': 'error',
+        'import/prefer-default-export': 'off',
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                args: 'none',
+                ignoreRestSiblings: true,
+            },
+        ],
+    },
+    overrides: [
+        {
+            files: ['**/*.stories.*'],
+            rules: {
+                'import/no-anonymous-default-export': 'off',
+            },
+        },
+        {
+            files: [
+                '*.ts',
+                '**/*.test.js',
+                '**/*.test.jsx',
+                '**/*.test.tsx',
+                '**/*.spec.js',
+                '**/*.spec.jsx',
+                '**/*.spec.tsx',
+            ],
+            rules: {
+                'no-undef': 'off',
+            },
+            env: {
+                jest: true,
+            },
+        },
+    ],
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+build
+node_modules
+.github

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+    printWidth: 80,
+    tabWidth: 2,
+    singleQuote: true,
+    semi: true,
+    trailingComma: 'all',
+    arrowParens: 'always',
+    noBracketSpacing: false,
+    overrides: [
+        {
+            files: '*.{js,jsx,tsx,ts,scss,json,html}',
+            options: {
+                tabWidth: 4,
+            },
+        },
+    ],
+};

--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "prettier": "^2.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,6 +4092,11 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-config-react-app@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz#0fa96d5ec1dfb99c029b1554362ab3fa1c3757df"
@@ -4179,6 +4184,13 @@ eslint-plugin-jsx-a11y@^6.5.1:
     jsx-ast-utils "^3.2.1"
     language-tags "^1.0.5"
     minimatch "^3.0.4"
+
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-react-hooks@^4.3.0:
   version "4.4.0"
@@ -4435,6 +4447,11 @@ fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
@@ -7332,6 +7349,18 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"


### PR DESCRIPTION
## Description
This PR adds [eslint](https://www.npmjs.com/package/eslint) and [prettier](https://www.npmjs.com/package/prettier) configuration files with few missing npm libraries that are required for proper work. 
Eslint -> checking code for possible errors and mistakes + makes it prettier;
Prettier: -> formatting code to make it more readable;

**NOTE**: Don't forget to run `yarn install` after!

### Update WebStorm preferences. It means that WebStorm need to format code after "Save".
![2022-04-10_20-57-43](https://user-images.githubusercontent.com/22501553/162633088-5af9b901-bc26-456c-9f48-ad4d62e5e8ff.jpg)


## Changes

## Screenshots/Videos


https://user-images.githubusercontent.com/22501553/162633128-c7469e06-5a1b-467f-bae2-c43b20acc8c6.mp4


## Checklist
- [ ] Contains no duplicate/temporary code
- [ ] Unit tests added

## Related PRs
- Part 2: ...
- Part 3: ...
